### PR TITLE
Fix non-unique column names in model DataFrame when using anonymous accessor functions

### DIFF
--- a/src/simulations/collect.jl
+++ b/src/simulations/collect.jl
@@ -403,7 +403,7 @@ function init_model_dataframe(model::ABM, properties::Vector)
                 current_type[]
             end
     end
-    DataFrame(types, headers)
+    DataFrame(types, headers, makeunique=true)
 end
 
 init_model_dataframe(model::ABM, properties::Nothing) = DataFrame()


### PR DESCRIPTION

This PR changes `init_model_dataframe` to pass `makeunique=true` to the DataFrame constructor. This allows one to use dynamically generated accessor functions in `mdata` with the same internal identifier.

For example, to split the elements of an array in the model properties separate DataFrame columns one can write:
```julia
mdata = [(model) -> model.value_array[i] for i=1:N]
init_model_dataframe(model, mdata)
```
However, this fails because the resulting column names (generated from Julia's identifiers of the anonymous functions `(model) -> model.value_array[i]`) are non-unique:
```
LoadError: ArgumentError: Duplicate variable names: :#543. Pass makeunique=true to make them unique using a suffix automatically.
```

The simple fix implemented here is to instruct DataFrame to make the column names unique.